### PR TITLE
Load commands also from menu items in extension menus

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,8 +59,8 @@ define(function (require, exports, module) {
         
         // Get list of all top-level menu bar menus
         // Ignore context menus since it seems less safe to assume those commands can be run in isolation
-        var menuIds = $.map(Menus.AppMenuBar, function (menuConstVal, menuConstName) {
-            return menuConstVal;
+        var menuIds = $.map(Menus.getAllMenus(), function (menuItem, menuId) {
+            return menuId;
         });
         
         // Filter command list accordingly
@@ -76,6 +76,7 @@ define(function (require, exports, module) {
                     var menuItemId = menu && menu._getMenuItemId(id);
                     if (Menus.getMenuItem(menuItemId)) {
                         noArgsOk = true;
+                        return;
                     }
                 });
             }


### PR DESCRIPTION
The plugin in it's current state displays only commands which have a key mapping or which are also displayed in one of brackets main menus. However it does not cover commands which were added by extensions to their own menus.  
This patch fixes this - commands from extension menus will also be recognized.
